### PR TITLE
hip_osc.cc: add barrier for lock/unlock

### DIFF
--- a/src/hip_osc.cc
+++ b/src/hip_osc.cc
@@ -196,6 +196,13 @@ int type_osc_test (void *sbuf, void *rbuf, int count,
         return ret;
     }
 #endif
-    
+
+#ifdef HIP_MPITEST_OSC_LOCK
+    ret = MPI_Barrier(comm);
+    if (MPI_SUCCESS != ret) {
+        return ret;
+    }
+#endif
+
     return MPI_SUCCESS;
 }


### PR DESCRIPTION
need to add a barrier for lock/unlock operations since otherwise the root process might perform the buffer check before the actual communication occured. Not necessary with Win_fence, since this operations acts synchronizing already anyway.