### PR TITLE
add non power-of-2 testcases

### DIFF
--- a/scripts/run_all_impl.sh.in
+++ b/scripts/run_all_impl.sh.in
@@ -74,4 +74,5 @@ ExecTest "hip_reduce_scatter"       "4" "1024"       "D H"
 ExecTest "hip_reduce_scatter_block" "4" "1024"       "D H"
 ExecTest "hip_pt2pt_nb_stress"      "2" "32 1048576" "D H M O R"
 ExecTest "hip_sendtoself_stress"    "1" "32 1048576" "D H M O R"
+ExecTest "hip_pt2pt_bl"             "2" "10 876 19680 980571" "D H"
 printf "\n Executed %d Tests (%d passed %d failed)\n" $COUNTER $SUCCESS $FAILED


### PR DESCRIPTION
make sure that we test some message length that are not an exact power of 2 in length.