### PR TITLE
add a new test to stress buffer management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ hip_pt2pt_nb
 hip_pt2pt_nb_stress
 hip_pt2pt_nb_testall
 hip_pt2pt_bl
+hip_pt2pt_bl_mult
 hip_pt2pt_bsend
 hip_pt2pt_ssend
 hip_pt2pt_persistent

--- a/scripts/run_all_impl.sh.in
+++ b/scripts/run_all_impl.sh.in
@@ -79,4 +79,5 @@ ExecTest "hip_reduce_scatter_block" "4" "1024"       "D H"
 ExecTest "hip_pt2pt_nb_stress"      "2" "32 1048576" "D H M O R"
 ExecTest "hip_sendtoself_stress"    "1" "32 1048576" "D H M O R"
 ExecTest "hip_pt2pt_bl"             "2" "10 876 19680 980571" "D H"
+ExecTest "hip_pt2pt_bl_mult"        "2" "1024" "D H"
 printf "\n Executed %d Tests (%d passed %d failed)\n" $COUNTER $SUCCESS $FAILED

--- a/scripts/run_all_no_ucx.sh
+++ b/scripts/run_all_no_ucx.sh
@@ -3,7 +3,7 @@
 # Copyright (c) 2022      Advanced Micro Devices, Inc. All rights reserved.
 #
 
-OPTIONS="--mca coll ^hcoll --mca pml ^ucx --mca osc ^ucx --mca btl ^openib,uct"
+OPTIONS=" --mca coll ^hcoll --mca pml ^ucx --mca osc ^ucx --mca btl ^openib,uct "
 
 ExecTest() {
 
@@ -58,4 +58,5 @@ ExecTest "hip_reduce_scatter_block" "4" "1024"       "D H"
 ExecTest "hip_pt2pt_nb_stress"      "2" "32 1048576" "D H M O R"
 ExecTest "hip_sendtoself_stress"    "1" "32 1048576" "D H M O R"
 ExecTest "hip_pt2pt_bl"             "2" "10 876 19680 980571" "D H"
+ExecTest "hip_pt2pt_bl_mult"        "2" "1024" "D H"
 printf "\n Executed %d Tests (%d passed %d failed)\n" $COUNTER $SUCCESS $FAILED

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -9,6 +9,7 @@ HEADERS = hip_mpitest_utils.h hip_mpitest_buffer.h hip_mpitest_datatype.h
 
 EXECS = hip_pt2pt_nb           \
         hip_pt2pt_bl           \
+        hip_pt2pt_bl_mult      \
 	hip_pt2pt_nb_testall   \
 	hip_pt2pt_nb_stress        \
 	hip_pt2pt_bsend            \
@@ -64,6 +65,9 @@ hip_reduce_scatter_block: hip_reduce_scatter.cc $(HEADERS)
 
 hip_pt2pt_bl: hip_pt2pt_bl.cc $(HEADERS)
 	$(CXX) $(CPPFLAGS) -o hip_pt2pt_bl hip_pt2pt_bl.cc $(LDFLAGS)
+
+hip_pt2pt_bl_mult: hip_pt2pt_bl_mult.cc $(HEADERS)
+	$(CXX) $(CPPFLAGS) -o hip_pt2pt_bl_mult hip_pt2pt_bl_mult.cc $(LDFLAGS)
 
 hip_pt2pt_bsend: hip_pt2pt_bl.cc $(HEADERS)
 	$(CXX) $(CPPFLAGS) -o hip_pt2pt_bsend hip_pt2pt_bl.cc -DHIP_MPITEST_BSEND $(LDFLAGS)
@@ -175,7 +179,7 @@ endif
 clean:
 	$(RM) *.o *~
 	$(RM) hip_scatter hip_scatterv hip_reduce_scatter hip_reduce_scatter_block
-	$(RM) hip_pt2pt_nb hip_pt2pt_nb_testall hip_pt2pt_nb_stress hip_pt2pt_bl hip_pt2pt_ssend
+	$(RM) hip_pt2pt_nb hip_pt2pt_nb_testall hip_pt2pt_nb_stress hip_pt2pt_bl hip_pt2pt_bl_mult hip_pt2pt_ssend
 	$(RM) hip_sendtoself hip_sendtoself_stress hip_pack hip_unpack hip_pt2pt_persistent hip_pt2pt_bsend
 	$(RM) hip_allreduce hip_reduce hip_iallreduce hip_ireduce hip_alltoall hip_alltoallv
 	$(RM) hip_allgather hip_allgatherv hip_gather hip_gatherv

--- a/src/hip_pt2pt_bl_mult.cc
+++ b/src/hip_pt2pt_bl_mult.cc
@@ -1,0 +1,165 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+** Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+*/
+
+#include <stdio.h>
+#include "mpi.h"
+
+#include <hip/hip_runtime.h>
+
+#include "hip_mpitest_utils.h"
+#include "hip_mpitest_buffer.h"
+
+int elements = 1024;
+hip_mpitest_buffer *sendbuf = NULL;
+hip_mpitest_buffer *recvbuf = NULL;
+
+static void init_sendbuf(int *sendbuf, int count, int val)
+{    
+    for (int i = 0; i < count; i++) {
+        sendbuf[i] = val;
+    }
+}
+
+static void init_recvbuf(int *recvbuf, int count)
+{
+    for (int i = 0; i < count; i++) {
+        recvbuf[i] = 0;
+    }
+}
+
+static bool check_recvbuf(int *recvbuf, int result, int count)
+{
+    bool res = true;
+
+    for (int i = 0; i < count; i++) {
+        if (recvbuf[i] != result) {
+            res = false;
+#ifdef VERBOSE
+            printf("recvbuf[%d] = %d expected %d\n", i, recvbuf[i], result);
+#endif
+            break;
+        }
+    }
+    return res;
+}
+
+int type_p2p_bl_mult_test(int *sendbuf, int *recvbuf, int count, MPI_Comm comm);
+
+/* High level idea of this test is to stress sycnhronization between of buffers
+** between Sender and Receiver.
+**  - Sender has a single send buffer that is used across all iterations
+**  - In every iteration Sender changes the Send buffer
+**  - Receiver has a separate receive buffer for every iteration
+**  - Receive buffers are checked for correctnes after all communications
+**    are done.
+*/
+int main(int argc, char *argv[])
+{
+    int rank, nProcs;
+    int root = 0;
+    int nIter = 10;
+
+    bind_device();
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_size(MPI_COMM_WORLD, &nProcs);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    if (nProcs != 2) {
+        printf("This test requires exactly two processes!\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+        return 1;
+    }
+    parse_args(argc, argv, MPI_COMM_WORLD);
+
+    int *tmp_sendbuf = NULL, *tmp_recvbuf = NULL;
+    // Initialise send buffer
+    if (rank == 0) {
+        ALLOCATE_SENDBUFFER(sendbuf, tmp_sendbuf, int, elements, sizeof(int),
+                            rank, MPI_COMM_WORLD, init_sendbuf);
+    }
+
+    // Initialize recv buffer
+    if (rank == 1) {
+        ALLOCATE_RECVBUFFER(recvbuf, tmp_recvbuf, int, nIter *elements, sizeof(int),
+                            rank, MPI_COMM_WORLD, init_recvbuf);
+    }
+
+    // execute point-to-point operations
+    for (int i=0; i<nIter; i++)  {
+        int *rbuf = NULL;
+        int *sbuf = NULL;
+
+        if (rank == 0) {
+            sbuf = (int *)sendbuf->get_buffer();        
+            init_sendbuf (sbuf, elements, i+1);
+        } else if (rank == 1){
+            rbuf = (int *)recvbuf->get_buffer() + i*elements;
+        }
+
+        int res = type_p2p_bl_mult_test(sbuf, rbuf, elements, MPI_COMM_WORLD);
+        if (MPI_SUCCESS != res) {
+            printf("Error in type_p2p_bl_mult_test. Aborting\n");
+            MPI_Abort(MPI_COMM_WORLD, 1);
+            return 1;
+        }
+    }
+
+    // verify results
+    bool ret = true;
+    if (rank == 1) {
+        int *rbuf_base = (int *)recvbuf->get_buffer();
+        if (recvbuf->NeedsStagingBuffer()) {
+            HIP_CHECK(recvbuf->CopyFrom(tmp_recvbuf, nIter * elements * sizeof(int)));
+            rbuf_base = tmp_recvbuf;
+        }
+        for (int i = 0; i <nIter; i++) {
+            int *rbuf = rbuf_base + i * elements;
+            ret = check_recvbuf(rbuf, i+1, elements);
+            if (ret != true) {
+                break;
+            }
+        }
+    }
+    bool fret = report_testresult(argv[0], MPI_COMM_WORLD, sendbuf->get_memchar(), recvbuf->get_memchar(), ret);
+
+    // Cleanup dynamic buffers
+    if (rank == 0) {
+        FREE_BUFFER(sendbuf, tmp_sendbuf);
+        delete (sendbuf);
+    }
+    if (rank == 1) {
+        FREE_BUFFER(recvbuf, tmp_recvbuf);
+        delete (recvbuf);
+    }
+
+    MPI_Finalize();
+    return fret ? 0 : 1;
+}
+
+int type_p2p_bl_mult_test(int *sbuf, int *rbuf, int count, MPI_Comm comm)
+{
+    int size, rank, ret;
+    int tag = 251;
+    MPI_Status status;
+
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    if (rank == 0) {
+        ret = MPI_Send(sbuf, count, MPI_INT, 1, tag, comm);
+        if (MPI_SUCCESS != ret) {
+            return ret;
+        }
+    }
+    if (rank == 1) {
+        ret = MPI_Recv(rbuf, count, MPI_INT, 0, tag, comm, &status);
+        if (MPI_SUCCESS != ret) {
+            return ret;
+        }
+    }
+
+    return MPI_SUCCESS;
+}


### PR DESCRIPTION
High level idea of this test is to stress sycnhronization between of buffers between Sender and Receiver.
  - Sender has a single send buffer that is used across all iterations
  - In every iteration Sender changes the Send buffer
  - Receiver has a separate receive buffer for every iteration
  - Receive buffers are checked for correctnes after all communications are done