### PR TITLE
fix initialization of sendbuffer in bl_mult

### DIFF
--- a/src/hip_pt2pt_bl_mult.cc
+++ b/src/hip_pt2pt_bl_mult.cc
@@ -93,8 +93,15 @@ int main(int argc, char *argv[])
         int *sbuf = NULL;
 
         if (rank == 0) {
-            sbuf = (int *)sendbuf->get_buffer();        
-            init_sendbuf (sbuf, elements, i+1);
+            if (sendbuf->NeedsStagingBuffer()) {
+                init_sendbuf(tmp_sendbuf, elements, i+1);
+                HIP_CHECK(sendbuf->CopyTo(tmp_sendbuf, elements * sizeof(int)));
+                sbuf = (int *)sendbuf->get_buffer();
+            }
+            else {
+                sbuf = (int *)sendbuf->get_buffer();
+                init_sendbuf(sbuf, elements, i+1);
+            }
         } else if (rank == 1){
             rbuf = (int *)recvbuf->get_buffer() + i*elements;
         }


### PR DESCRIPTION
Fix the initialization of the sendbuffer in hip_pt2pt_bl_mult by using hipMemcpy in case of device buffers (instead of relying on large BAR support).