### PR TITLE
free inactive persistent requests

### DIFF
--- a/src/hip_pt2pt_nb.cc
+++ b/src/hip_pt2pt_nb.cc
@@ -237,6 +237,9 @@ int type_p2p_persistent_test (int *sbuf, int *rbuf, int count, MPI_Comm comm)
     if (MPI_SUCCESS != ret) {
         goto out;
     }
+    for (int i=0; i<size*2; i++) {
+        MPI_Request_free(&reqs[i]);
+    }
 
  out:
     free (reqs);


### PR DESCRIPTION
## Motivation

Unfreed persistent requests produce warnings with debug builds of MPICH at `MPI_Finalize`. E.g.
```
hip_pt2pt_persistent M H :       	 [SUCCESS]
MPICH: freeing inactive persistent request ac000000 on communicator 44000000.
MPICH: freeing inactive persistent request ac000001 on communicator 44000000.
MPICH: freeing inactive persistent request ac000002 on communicator 44000000.
MPICH: freeing inactive persistent request ac000003 on communicator 44000000.
MPICH: freeing inactive persistent request ac000000 on communicator 44000000.
MPICH: freeing inactive persistent request ac000001 on communicator 44000000.
MPICH: freeing inactive persistent request ac000002 on communicator 44000000.
MPICH: freeing inactive persistent request ac000003 on communicator 44000000.
```

## Technical Details

Free persistent requests when they are no longer used.

## Test Plan

Tested on ANL internal build system https://www.jlse.anl.gov/amd-gpu-mi100.

## Test Result

Unfreed request warnings are resolved.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
